### PR TITLE
[feature/fetch_range] 일정 범위만 fetch하는 함수 추가

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/CoredataLayer.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoredataLayer.swift
@@ -56,12 +56,12 @@ class CoreDataLayer {
     }
     
     func fetch(southWest: LatLng, northEast: LatLng) throws -> [POI] {
-        guard northEast.lat < southWest.lat,
+        guard northEast.lat > southWest.lat,
               northEast.lng > southWest.lng else {
             throw CoreDataError.invalidCoordinate
         }
         
-        let latitudePredicate = NSPredicate(format: "latitude BETWEEN {%@, %@}", argumentArray: [northEast.lat, southWest.lat])
+        let latitudePredicate = NSPredicate(format: "latitude BETWEEN {%@, %@}", argumentArray: [southWest.lat, northEast.lat])
         let longitudePredicate = NSPredicate(format: "longitude BETWEEN {%@, %@}", argumentArray: [southWest.lng, northEast.lng])
         let predicate = NSCompoundPredicate(type: .and, subpredicates: [latitudePredicate, longitudePredicate])
         

--- a/BoostClusteringMaB/BoostClusteringMaB/CoredataLayer.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoredataLayer.swift
@@ -10,6 +10,7 @@ import CoreData
 protocol CoreDataManager {
     func add(place: Place, completion handler: (() -> Void)?) throws
     func fetch() throws -> [POI]
+    func fetch(southWest: LatLng, northEast: LatLng) throws -> [POI]
     func remove(at: Int) throws
     func removeAll() throws
     func save() throws

--- a/BoostClusteringMaB/BoostClusteringMaBTests/CoreDataTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/CoreDataTests.swift
@@ -49,6 +49,38 @@ class CoreDataTests: XCTestCase {
         print(pois.count)
     }
     
+    func testFetchPOIBetweenY30_45X120_135_All() throws {
+        // Given
+        let layer = CoreDataLayer()
+        
+        // When
+        let pois = try layer.fetch(southWest: LatLng(lat: 45, lng: 120), northEast: LatLng(lat: 30, lng: 135))
+        
+        // Then
+        let all = try layer.fetch()
+        XCTAssertEqual(pois.count, all.count)
+    }
+    
+    func testFetchPOIBetweenY30_45X135_145_Empty() throws {
+        // Given
+        let layer = CoreDataLayer()
+        
+        // When
+        let pois = try layer.fetch(southWest: LatLng(lat: 45, lng: 135), northEast: LatLng(lat: 30, lng: 145))
+        
+        // Then
+        XCTAssertTrue(pois.isEmpty)
+    }
+    
+    func testFetchPOIBetweenY45_30X120_135_invalidCoordinate() throws {
+        // Given
+        let layer = CoreDataLayer()
+        
+        // Then
+        XCTAssertThrowsError(try layer.fetch(southWest: LatLng(lat: 30, lng: 120),
+                                             northEast: LatLng(lat: 45, lng: 135)))
+    }
+    
     func testAdd10000POI() throws {
         try timeout(30) { expectation in
             // Given

--- a/BoostClusteringMaB/BoostClusteringMaBTests/CoreDataTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/CoreDataTests.swift
@@ -54,7 +54,7 @@ class CoreDataTests: XCTestCase {
         let layer = CoreDataLayer()
         
         // When
-        let pois = try layer.fetch(southWest: LatLng(lat: 45, lng: 120), northEast: LatLng(lat: 30, lng: 135))
+        let pois = try layer.fetch(southWest: LatLng(lat: 30, lng: 120), northEast: LatLng(lat: 45, lng: 135))
         
         // Then
         let all = try layer.fetch()
@@ -66,7 +66,7 @@ class CoreDataTests: XCTestCase {
         let layer = CoreDataLayer()
         
         // When
-        let pois = try layer.fetch(southWest: LatLng(lat: 45, lng: 135), northEast: LatLng(lat: 30, lng: 145))
+        let pois = try layer.fetch(southWest: LatLng(lat: 30, lng: 135), northEast: LatLng(lat: 45, lng: 145))
         
         // Then
         XCTAssertTrue(pois.isEmpty)
@@ -77,8 +77,8 @@ class CoreDataTests: XCTestCase {
         let layer = CoreDataLayer()
         
         // Then
-        XCTAssertThrowsError(try layer.fetch(southWest: LatLng(lat: 30, lng: 120),
-                                             northEast: LatLng(lat: 45, lng: 135)))
+        XCTAssertThrowsError(try layer.fetch(southWest: LatLng(lat: 45, lng: 120),
+                                             northEast: LatLng(lat: 30, lng: 135)))
     }
     
     func testAdd10000POI() throws {


### PR DESCRIPTION
### CoreData로부터 일정 범위만 fetch하는 함수 추가

```Swift
func fetch(southWest: LatLng, northEast: LatLng) throws -> [POI]
```
parameters
- southWest: 가져오려는 범위의 남서쪽 좌표
- northEast: 가져오려는 범위의 북동쪽 좌표
throws
- CoreDataError.invalidCoordinate: 매개변수로 주어진 좌표가 올바르지 않을 때 발생하는 예외 (북동쪽의 위도가 남서쪽의 위도보다 큰 경우 등)

### 범위 fetch 테스트 코드 추가