### PR TITLE
[feature/coredata_add_point] 마커를 눌렀을 때 CoreData와 연동하여 추가하거나 삭제하는 기능 추가

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB.xcodeproj/project.pbxproj
+++ b/BoostClusteringMaB/BoostClusteringMaB.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		F49A2928256BEE2F0039998F /* XCTestCase+timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49A2927256BEE2F0039998F /* XCTestCase+timeout.swift */; };
 		F4A07BAE257118BF00B18415 /* Loading.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4A07BAD257118BF00B18415 /* Loading.storyboard */; };
 		F4A07BB225711B1900B18415 /* LoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A07BB125711B1900B18415 /* LoadViewController.swift */; };
+		F4C31B50257779D100103E98 /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C31B4F257779D100103E98 /* AlertType.swift */; };
 		F4DB7C2A25767EFF00789E35 /* UIImageView+loadImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DB7C2925767EFF00789E35 /* UIImageView+loadImage.swift */; };
 		F4E23D2B25727A5F008A9B4C /* DataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E23D2A25727A5F008A9B4C /* DataParser.swift */; };
 		F4FC20A2256B8AD200D97246 /* CoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC20A1256B8AD200D97246 /* CoreDataTests.swift */; };
@@ -131,6 +132,7 @@
 		F49A2927256BEE2F0039998F /* XCTestCase+timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+timeout.swift"; sourceTree = "<group>"; };
 		F4A07BAD257118BF00B18415 /* Loading.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Loading.storyboard; sourceTree = "<group>"; };
 		F4A07BB125711B1900B18415 /* LoadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadViewController.swift; sourceTree = "<group>"; };
+		F4C31B4F257779D100103E98 /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
 		F4DB7C2925767EFF00789E35 /* UIImageView+loadImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+loadImage.swift"; sourceTree = "<group>"; };
 		F4E23D2A25727A5F008A9B4C /* DataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataParser.swift; sourceTree = "<group>"; };
 		F4FC20A1256B8AD200D97246 /* CoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTests.swift; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 				708C08C0256258320072B1E0 /* MainViewController.swift */,
 				707E63E6257490EC003F0E10 /* MainInteractor.swift */,
 				707E63EA257490F5003F0E10 /* MainPresenter.swift */,
+				F4C31B4F257779D100103E98 /* AlertType.swift */,
 			);
 			path = MainView;
 			sourceTree = "<group>";
@@ -650,6 +653,7 @@
 				70E2A21F25776C0D009A5ADC /* NMFPolygonOverlay+.swift in Sources */,
 				C3A287A1256FA33A00DF23B1 /* ConvexHull.swift in Sources */,
 				DA805DDA2576834E0067325E /* DetailCollectionReusableView.swift in Sources */,
+				F4C31B50257779D100103E98 /* AlertType.swift in Sources */,
 				F4E23D2B25727A5F008A9B4C /* DataParser.swift in Sources */,
 				708C08C1256258320072B1E0 /* MainViewController.swift in Sources */,
 				708C08BD256258320072B1E0 /* AppDelegate.swift in Sources */,
@@ -881,7 +885,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8ULFNR9M33;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				INFOPLIST_FILE = BoostClusteringMaB/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/BoostClusteringMaB/BoostClusteringMaB/Clustering/Clustering.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Clustering/Clustering.swift
@@ -23,7 +23,9 @@ class Clustering {
     func findOptimalClustering(southWest: LatLng, northEast: LatLng) {
         let poi = coreDataLayer.fetch(southWest: southWest, northEast: northEast, sorted: true)
         guard let pois = poi?.map({$0.toPOI()}) else { return }
-        guard !pois.isEmpty else { return }
+        guard !pois.isEmpty else {
+            return
+        }
         runKMeans(pois: pois)
     }
 

--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
@@ -26,6 +26,7 @@ protocol CoreDataManager {
                sorted: Bool
                 ) -> [ManagedPOI]?
     func remove(poi: ManagedPOI, completion handler: CoreDataHandler?)
+    func remove(location: LatLng, completion handler: CoreDataHandler?)
     func removeAll(completion handler: CoreDataHandler?)
     func makeFetchResultsController(southWest: LatLng,
                                     northEast: LatLng) -> NSFetchedResultsController<ManagedPOI>
@@ -154,6 +155,19 @@ final class CoreDataLayer: CoreDataManager {
         return try? childContext.fetch(request)
     }
     
+    private func fetch(location: LatLng) -> ManagedPOI? {
+        let latitudePredicate = NSPredicate(format: "latitude == %@",
+                                            argumentArray: [location.lat])
+        let longitudePredicate = NSPredicate(format: "longitude == %@",
+                                             argumentArray: [location.lng])
+        let predicate = NSCompoundPredicate(type: .and, subpredicates: [latitudePredicate, longitudePredicate])
+        
+        let request: NSFetchRequest = ManagedPOI.fetchRequest()
+        request.predicate = predicate
+        
+        return try? childContext.fetch(request).first
+    }
+    
     private func makeSortDescription(sorted: Bool) -> [NSSortDescriptor]? {
         let latitudeSort = NSSortDescriptor(key: "latitude", ascending: true)
         let longitudeSort = NSSortDescriptor(key: "longitude", ascending: true)
@@ -169,6 +183,15 @@ final class CoreDataLayer: CoreDataManager {
         } catch {
             handler?(.failure(.saveError))
         }
+    }
+    
+    func remove(location: LatLng, completion handler: CoreDataHandler?) {
+        guard let managedPOI = fetch(location: location) else {
+            handler?(.failure(.invalidFetch))
+            return
+        }
+        
+        remove(poi: managedPOI, completion: handler)
     }
     
     func removeAll(completion handler: CoreDataHandler?) {

--- a/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
@@ -19,6 +19,8 @@ extension NMFMarker {
     static func markers(latLngs: [LatLng], pointSizes: [Int]) -> [NMFMarker] {
         return zip(latLngs, pointSizes).map { latLng, pointSize in
             let marker = NMFMarker(position: NMGLatLng(lat: latLng.lat, lng: latLng.lng))
+            marker.captionText = "\(pointSize)"
+            marker.captionTextSize = 0
             guard pointSize != 1 else { return marker }
             marker.setImageView(markerImageView, count: pointSize)
             return marker

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/AlertType.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/AlertType.swift
@@ -1,0 +1,31 @@
+//
+//  AlertType.swift
+//  BoostClusteringMaB
+//
+//  Created by 현기엽 on 2020/12/02.
+//
+
+import Foundation
+
+enum AlertType {
+    case append
+    case delete
+    
+    var title: String {
+        switch self {
+        case .append:
+            return "POI를 추가하시겠습니까?"
+        case .delete:
+            return "POI를 제거하시겠습니까?"
+        }
+    }
+    
+    var message: String {
+        switch self {
+        case .append:
+            return "OK를 누르면 추가합니다."
+        case .delete:
+            return "OK를 누르면 제거합니다."
+        }
+    }
+}

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainInteractor.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainInteractor.swift
@@ -13,6 +13,8 @@ protocol MainDataStore {
 
 protocol MainBusinessLogic {
     func fetchPOI(southWest: LatLng, northEast: LatLng)
+    func addLocation(_ latlng: LatLng, southWest: LatLng, northEast: LatLng)
+    func deleteLocation(_ latlng: LatLng, southWest: LatLng, northEast: LatLng)
 }
 
 final class MainInteractor: MainDataStore {
@@ -32,8 +34,23 @@ final class MainInteractor: MainDataStore {
 }
 
 extension MainInteractor: MainBusinessLogic {
-
     func fetchPOI(southWest: LatLng, northEast: LatLng) {
         clustering?.findOptimalClustering(southWest: southWest, northEast: northEast)
+    }
+    
+    func addLocation(_ latlng: LatLng, southWest: LatLng, northEast: LatLng) {
+        coreDataLayer.add(place: Place(id: "9999", name: "새로운 데이터",
+                                       x: "\(latlng.lng)",
+                                       y: "\(latlng.lat)",
+                                       imageURL: nil,
+                                       category: "new")) { _ in
+            self.fetchPOI(southWest: southWest, northEast: northEast)
+        }
+    }
+    
+    func deleteLocation(_ latlng: LatLng, southWest: LatLng, northEast: LatLng) {
+        coreDataLayer.remove(location: latlng) { _ in
+            self.fetchPOI(southWest: southWest, northEast: northEast)
+        }
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaBTests/Mocks/CoreDataLayerMock.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/Mocks/CoreDataLayerMock.swift
@@ -33,6 +33,10 @@ class CoreDataLayerMock: CoreDataManager {
 
     }
 
+    func remove(location: LatLng, completion handler: CoreDataHandler?) {
+        
+    }
+    
     func removeAll(completion handler: CoreDataHandler?) {
 
     }


### PR DESCRIPTION
### 구현 내용
- 마커를 눌렀을 때 CoreData와 연동하여 추가하거나 삭제하는 기능 추가
  - caption을 이용하여 마커가 가지고 있는 POI의 개수를 저장
  - captionTextSize를 이용하여 사용자가 볼 수 없도록 저장
  - location을 바탕으로 코어데이터에서 제거하는 기능 추가