### PR TITLE
[Feature/unit test] Unit Test를 위한 AddressAPI, JSONParser Protocol 생성

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
@@ -34,6 +34,9 @@ protocol CoreDataManager {
 }
 
 final class CoreDataLayer: CoreDataManager {
+    var addressAPI: AddressAPIService = AddressAPI()
+    var jsonParser: JsonParserService = JsonParser()
+    
     private lazy var childContext: NSManagedObjectContext = {
         let childContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         
@@ -58,9 +61,6 @@ final class CoreDataLayer: CoreDataManager {
                                           sectionNameKeyPath: nil,
                                           cacheName: nil)
     }
-
-    let addressAPI = AddressAPI()
-    let jsonParser = JsonParser()
 
     private func add(place: Place, isSave: Bool, completion handler: CoreDataHandler? = nil) {
         guard let latitude = Double(place.y),

--- a/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
@@ -39,7 +39,7 @@ final class AddressAPI: AddressAPIService {
             guard let httpResponse = response as? HTTPURLResponse,
                   200...299 ~= httpResponse.statusCode else {
                 completion?(.failure(AddressAPIError.nmfClientError))
-                debugPrint(response)
+                debugPrint(response ?? "")
                 return
             }
             

--- a/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-final class AddressAPI {
+protocol AddressAPIService {
+    func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?)
+}
+
+final class AddressAPI: AddressAPIService {
     enum AddressAPIError: Error {
         case nmfClientError
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Util/JsonParser.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Util/JsonParser.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-class JsonParser: DataParser {
+protocol JsonParserService {
+    func parse(fileName: String, completion handler: @escaping (Result<[Place], Error>) -> Void)
+    func parse(address: Data) -> String?
+}
+
+class JsonParser: DataParser, JsonParserService {
     typealias DataType = Place
     private let type = "json"
     

--- a/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
@@ -16,25 +16,43 @@ class CoreDataTests: XCTestCase {
                          y: "35.55532",
                          imageURL: nil,
                          category: "부스트캠프")
-    
+
+    class AddressAPIMock: AddressAPIService {
+        func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) {
+            completion?(.success(.init()))
+        }
+    }
+
+    class JSONParserMock: JsonParserService {
+        func parse(fileName: String, completion handler: @escaping (Result<[Place], Error>) -> Void) {
+            handler(.success([]))
+        }
+
+        func parse(address: Data) -> String? {
+            return ""
+        }
+    }
+
     func testAddPOI() throws {
-//        // Given
-//        let layer = CoreDataLayer()
-//
-//        timeout(1) { expectation in
-//            // When
-//            layer.add(place: newPlace) { _ in
-//                let poi = layer.fetch()?.first
-//                // Then
-//                XCTAssertEqual(poi?.id, "123321")
-//                XCTAssertEqual(poi?.category, "부스트캠프")
-//                XCTAssertEqual(poi?.imageURL, nil)
-//                XCTAssertEqual(poi?.name, "Mab")
-//                XCTAssertEqual(poi?.latitude, 35.55532)
-//                XCTAssertEqual(poi?.longitude, 124.323412)
-//                expectation.fulfill()
-//            }
-//        }
+        // Given
+        let layer = CoreDataLayer()
+        layer.addressAPI = AddressAPIMock()
+        layer.jsonParser = JSONParserMock()
+
+        timeout(1) { expectation in
+            // When
+            layer.add(place: newPlace) { _ in
+                let poi = layer.fetch()?.first
+                // Then
+                XCTAssertEqual(poi?.id, "123321")
+                XCTAssertEqual(poi?.category, "부스트캠프")
+                XCTAssertEqual(poi?.imageURL, nil)
+                XCTAssertEqual(poi?.name, "Mab")
+                XCTAssertEqual(poi?.latitude, 35.55532)
+                XCTAssertEqual(poi?.longitude, 124.323412)
+                expectation.fulfill()
+            }
+        }
     }
     
     func test_add_잘못된좌표를입력_invalidCoordinate() throws {

--- a/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
@@ -142,49 +142,52 @@ class CoreDataTests: XCTestCase {
         XCTAssertTrue( pois.allSatisfy({ poi -> Bool in poi.category == "부스트캠프" }) )
     }
     
-    //    func testAdd10000POI() throws {
-    //        timeout(40) { expectation in
-    //            // Given
-    //            let numberOfRepeats = 10000
-    //            let layer = CoreDataLayer()
-    //            let places = (0..<numberOfRepeats).map { _ in newPlace }
-    //            let beforeCount = layer.fetch()?.count
-    //
-    //            // When
-    //            layer.add(places: places) { _ in
-    //                let afterCount = layer.fetch()?.count
-    //
-    //                // Then
-    //                XCTAssertNotNil(beforeCount)
-    //                XCTAssertEqual(beforeCount! + numberOfRepeats, afterCount)
-    //                expectation.fulfill()
-    //                }
-    //            }
-    //        }
-    
-    func testRemove() throws {
-//        // Given
-//        let layer = CoreDataLayer()
-//        timeout(20) { expectation in
-//            layer.add(place: newPlace) { _ in
-//                let pois = layer.fetch()
-//                guard let poi = pois?.first(where: { poi -> Bool in
-//                    poi.id == self.newPlace.id
-//                }),
-//                let beforeCount = pois?.count else {
-//                    XCTFail("data add fail")
-//                    return
-//                }
-//                
-//                // When
-//                layer.remove(poi: poi) { _ in }
-//                
-//                // Then
+//    func testAdd10000POI() throws {
+//        timeout(40) { expectation in
+//            // Given
+//            let numberOfRepeats = 10000
+//            let layer = CoreDataLayer()
+//            let places = (0..<numberOfRepeats).map { _ in newPlace }
+//            let beforeCount = layer.fetch()?.count
+//
+//            // When
+//            layer.add(places: places) { _ in
 //                let afterCount = layer.fetch()?.count
-//                XCTAssertEqual(beforeCount - 1, afterCount)
+//
+//                // Then
+//                XCTAssertNotNil(beforeCount)
+//                XCTAssertEqual(beforeCount! + numberOfRepeats, afterCount)
 //                expectation.fulfill()
 //            }
 //        }
+//    }
+    
+    func testRemove() throws {
+        // Given
+        let layer = CoreDataLayer()
+        layer.addressAPI = AddressAPIMock()
+        layer.jsonParser = JSONParserMock()
+        
+        timeout(20) { expectation in
+            layer.add(place: newPlace) { _ in
+                let pois = layer.fetch()
+                guard let poi = pois?.first(where: { poi -> Bool in
+                    poi.id == self.newPlace.id
+                }),
+                let beforeCount = pois?.count else {
+                    XCTFail("data add fail")
+                    return
+                }
+
+                // When
+                layer.remove(poi: poi) { _ in }
+
+                // Then
+                let afterCount = layer.fetch()?.count
+                XCTAssertEqual(beforeCount - 1, afterCount)
+                expectation.fulfill()
+            }
+        }
     }
     
     func testRemoveAll() throws {


### PR DESCRIPTION
- AddressAPI에 위도와 경도를 입력하면 주소를 받아오는 API가 존재합니다.
- 아래 코드와 같이 주소가 불려지면 Coredata에 add를 시작합니다.
```swift
addressAPI.address(lat: latitude, lng: longitude) { result in
    guard let address = try? self.jsonParser.parse(address: result.get()) else { return }
    self.childContext.perform { [weak self] in
        guard let self = self else {
            return
        }
        let poi = ManagedPOI(context: self.childContext)
        poi.fromPOI(place, address)
        if isSave {
            do {
                try self.save()
            } catch {
                handler?(.failure(.saveError))
                return
            }
        }
        handler?(.success(()))
    }
}
```
- 위와 같이 test코드에서는 네트워크를 불릴 필요가 없기 때문에 AddressAPIMock(), JSONParserMock()를 만들어서 사용했습니다.
```swift
class AddressAPIMock: AddressAPIService {
     func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) {
         completion?(.success(.init()))
     }
 }
```
- 무조건 성공하는 case를 만들어 테스트를 진행했습니다.