### PR TITLE
[Feature/convex hull bug] ConvexHull 중복데이터 처리

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Clustering/Cluster.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Clustering/Cluster.swift
@@ -77,12 +77,11 @@ class Cluster: Equatable {
     }
     
     func area() -> [LatLng] {
-        let sortedPois = pois.allValues().sorted(by: {
-            ($0.latLng.lng, $0.latLng.lat) < ($1.latLng.lng, $1.latLng.lat)
-        })
-        let sortedPoints = sortedPois.map { LatLng(lat: $0.latLng.lat, lng: $0.latLng.lng) }
-        guard let first = sortedPoints.first else { return [] }
-        let convexHull = ConvexHull(stdPoint: first, points: sortedPoints)
+        let poisAllValues = pois.allValues()
+
+        let points = poisAllValues.map { LatLng(lat: $0.latLng.lat, lng: $0.latLng.lng) }
+
+        let convexHull = ConvexHull(poiPoints: points)
         let convexHullPoints = convexHull.run()
         return convexHullPoints
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Clustering/Clustering.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Clustering/Clustering.swift
@@ -77,7 +77,7 @@ class Clustering {
     }
     
     func combineClusters(clusters: [Cluster]) -> [Cluster] {
-        let stdDistance: Double = 90
+        let stdDistance: Double = 60
         var newClusters = clusters
         
         for i in 0..<clusters.count {

--- a/BoostClusteringMaB/BoostClusteringMaB/Clustering/ConvexHull.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Clustering/ConvexHull.swift
@@ -90,6 +90,7 @@ final class ConvexHull {
         }
 
         var result = stack.map { infos[$0] }
+
         result.append(result[0])
 
         return result.map({LatLng(lat: $0.y, lng: $0.x)})

--- a/BoostClusteringMaB/BoostClusteringMaB/Clustering/ConvexHull.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Clustering/ConvexHull.swift
@@ -7,63 +7,65 @@
 
 import Foundation
 
-struct Info {
-    let x: Double
-    let y: Double
-    let p: Double
-    let q: Double
-}
+final class ConvexHull {
+    private var points = [LatLng]() // x,y
+    private var relativePoints = [LatLng]() // p,q
+    private var infos: [Info] = []
 
-class ConvexHull {
-    let stdPoint: LatLng
-    let points: [LatLng] // x,y
-    var relativePoints: [LatLng] // p,q
-    var infos: [Info] = []
-    
-    init(stdPoint: LatLng, points: [LatLng]) {
-        self.stdPoint = stdPoint
-        self.points = points
+    struct Info {
+        let x: Double
+        let y: Double
+        let p: Double
+        let q: Double
+    }
+
+    init(poiPoints: [LatLng]) {
+        points = deduplication(points: poiPoints)
+        configureInfos()
+        infos = sortedPointsWithoutFirst()
+    }
+
+    private func configureInfos() {
+        let stdPoint = points[0]
+
         relativePoints = points
             .dropFirst()
             .map { $0 - stdPoint }
-        relativePoints.insert(LatLng(lat: 0, lng: 1), at: 0)
+
+        relativePoints.insert(stdPoint, at: 0)
+
         zip(points, relativePoints).forEach { point, reletivePoint in
             self.infos.append(Info(x: point.lng, y: point.lat, p: reletivePoint.lng, q: reletivePoint.lat))
         }
-        
+    }
+
+    private func deduplication(points: [LatLng]) -> [LatLng] {
+        let setPoiPoints = Set(points)
+        return Array(setPoiPoints).sorted(by: {
+            ($0.lat, $0.lng) < ($1.lat, $1.lng)
+        })
+    }
+
+    private func sortedPointsWithoutFirst() -> [Info] {
         var sortedPoints = infos.dropFirst().sorted(by: { left, right in
             if left.q * right.p != left.p * right.q {
                 return left.q * right.p < left.p * right.q
             }
-            
+
             if left.y != right.y {
                 return left.y < right.y
             }
-            
+
             return left.x < right.x
         })
-        
+
         if let first = infos.first {
             sortedPoints.insert(first, at: 0)
         }
-        
-        infos = sortedPoints
 
+        return sortedPoints
     }
-    
-    func ccw(point1: Info, point2: Info, point3: Info) -> Int {
-        var temp = point1.x * point2.y + point2.x * point3.y + point3.x * point1.y
-        temp = temp - point2.x * point1.y - point3.x * point2.y - point1.x * point3.y
-        
-        if temp > 0 {
-            return 1
-        } else if temp < 0 {
-            return -1
-        }
-        
-        return 0
-    }
-    
+
     func run() -> [LatLng] {
         var stack = [Int]()
         stack.append(0)
@@ -71,7 +73,7 @@ class ConvexHull {
         
         guard infos.count > 2 else { return [] }
         
-        var next: Int = 2
+        var next = 2
         
         while next < infos.count {
             while stack.count >= 2 {
@@ -86,8 +88,22 @@ class ConvexHull {
             stack.append(next)
             next += 1
         }
+
         var result = stack.map { infos[$0] }
-        result.append(infos[0])
+        result.append(result[0])
+
         return result.map({LatLng(lat: $0.y, lng: $0.x)})
+    }
+
+    private func ccw(point1: Info, point2: Info, point3: Info) -> Int {
+        var temp = point1.x * point2.y + point2.x * point3.y + point3.x * point1.y
+        temp = temp - point2.x * point1.y - point3.x * point2.y - point1.x * point3.y
+
+        if temp > 0 {
+            return 1
+        } else if temp < 0 {
+            return -1
+        }
+        return 0
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Loading/LoadViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Loading/LoadViewController.swift
@@ -13,7 +13,6 @@ class LoadViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         guard let pois = coreDataLayer.fetch() else {
             debugPrint("LoadViewController.viewDidAppear.load fail 알람창 만들기")
             return

--- a/BoostClusteringMaB/BoostClusteringMaBTests/Clustering/ConvexHullTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/Clustering/ConvexHullTests.swift
@@ -13,7 +13,6 @@ class ConvexHullTests: XCTestCase {
     func test_ConvexHull() {
         
         //Given
-        let stdPoint = LatLng(lat: 0.0, lng: 0.0)
         var points: [LatLng] = []
 
         points.append(LatLng(lat: 0.0, lng: 0.0))
@@ -23,7 +22,7 @@ class ConvexHullTests: XCTestCase {
         points.append(LatLng(lat: 0.6, lng: 0.7))
 
         //When
-        let convex = ConvexHull(stdPoint: stdPoint, points: points)
+        let convex = ConvexHull(poiPoints: points)
 
         //Then
         XCTAssertEqual(convex.run().count, 5)


### PR DESCRIPTION
- 중복데이터가 존재하면 아래와 같이 삐죽삐죽 이상하게 그려집니다.
![스크린샷 2020-12-03 오후 4 27 46](https://user-images.githubusercontent.com/46857148/100977556-7df38a80-3584-11eb-8040-e1d060cf48bb.png)

- 아래와 같이 들어온 데이터 중복 제거 한 후 다른 로직을 처리했습니다!
```swift
let setPoiPoints = Set(points)
return Array(setPoiPoints).sorted(by: {
    ($0.lat, $0.lng) < ($1.lat, $1.lng)
})
```
![스크린샷 2020-12-03 오후 4 31 51](https://user-images.githubusercontent.com/46857148/100977962-14c04700-3585-11eb-8f97-b10588b43464.png)
