### PR TITLE
[Hotfix/memory managed poi] ManagedPOI 메모리에서 사라지지 않는 현상

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -235,8 +235,8 @@ extension DetailViewController: UICollectionViewDelegateFlowLayout {
 extension DetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? DetailCollectionViewCell else { return }
-        guard let lat = cell.poi?.latitude,
-              let lng = cell.poi?.longitude else {
+        guard let lat = cell.latLng?.lat,
+              let lng = cell.latLng?.lng else {
             return
         }
         delegate?.didCellSelected(lat: lat, lng: lng, isClicked: cell.isClicked)

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
@@ -31,6 +31,7 @@ class DetailCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(poi: ManagedPOI) {
+        self.poi = nil
         self.poi = poi
         nameLabel.text = poi.name
         categoryLabel.text = poi.category

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
@@ -20,7 +20,7 @@ class DetailCollectionViewCell: UICollectionViewCell {
         return indicator
     }()
     
-    var poi: ManagedPOI?
+    var latLng: LatLng?
     var isClicked: Bool = false
     private weak var task: URLSessionTask?
     
@@ -31,8 +31,7 @@ class DetailCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(poi: ManagedPOI) {
-        self.poi = nil
-        self.poi = poi
+        self.latLng = LatLng(lat: poi.latitude, lng: poi.longitude)
         nameLabel.text = poi.name
         categoryLabel.text = poi.category
         addressLabel.text = poi.address


### PR DESCRIPTION
- ManagedPOI가 메모리에서 사라지지 않았다. 확인해보니 DetailCollectionViewCell에서 Cell을 다시 만들때 self.poi에서 nil을 해주지 않아 사라지지 않았다.