### PR TITLE
[feature/improving detailview] Detailview 개선

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -45,6 +45,7 @@ final class DetailViewController: UIViewController {
     
     private func configureView() {
         view.clipsToBounds = true
+        collectionView.isHidden = true
         view.layer.cornerRadius = 10
         dragBar.layer.cornerRadius = 3
     }
@@ -275,6 +276,7 @@ extension DetailViewController: UISearchBarDelegate {
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         UIView.animate(withDuration: 0.5) {
             self.currentState = .full
+            self.collectionView.isHidden = false
             self.moveView(state: self.currentState)
         }
     }
@@ -282,6 +284,7 @@ extension DetailViewController: UISearchBarDelegate {
     func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
         UIView.animate(withDuration: 0.5) {
             self.currentState = .partial
+            self.collectionView.isHidden = false
             self.moveView(state: self.currentState)
             self.view.endEditing(true)
         }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -131,10 +131,13 @@ extension DetailViewController {
         
         switch endedY {
         case ...fullAndPartialBound:
+            collectionView.isHidden = false
             return .full
         case ...partialAndMinimumBound:
+            collectionView.isHidden = false
             return .partial
         default:
+            collectionView.isHidden = true
             return .minimum
         }
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -14,7 +14,9 @@ protocol DetailViewControllerDelegate: class {
 
 final class DetailViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
-    @IBOutlet weak var searchBar: UISearchBar!
+    @IBOutlet weak var searchBar: UISearchBar! {
+        didSet { searchBar.delegate = self }
+    }
     @IBOutlet weak var dragBar: UIView!
     
     weak var delegate: DetailViewControllerDelegate?
@@ -266,5 +268,26 @@ extension DetailViewController: UICollectionViewDelegate {
         cell.isClicked = true
         prevClickedCell?.isClicked = false
         prevClickedCell = cell
+    }
+}
+
+extension DetailViewController: UISearchBarDelegate {
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        UIView.animate(withDuration: 0.5) {
+            self.currentState = .full
+            self.moveView(state: self.currentState)
+        }
+    }
+    
+    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        UIView.animate(withDuration: 0.5) {
+            self.currentState = .partial
+            self.moveView(state: self.currentState)
+            self.view.endEditing(true)
+        }
+    }
+    
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBarTextDidEndEditing(searchBar)
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -148,6 +148,7 @@ extension DetailViewController {
     @objc private func panGesture(_ recognizer: UIPanGestureRecognizer) {
         var nextState = moveView(panGestureRecognizer: recognizer)
         if recognizer.state == .ended {
+            self.view.endEditing(true)
             UIView.animate(withDuration: 0.5, delay: 0, options: [.allowUserInteraction]) {
                 if nextState == self.currentState {
                     nextState = recognizer.velocity(in: self.view).y >= 0
@@ -269,28 +270,33 @@ extension DetailViewController: UICollectionViewDelegate {
         cell.isClicked = true
         prevClickedCell?.isClicked = false
         prevClickedCell = cell
+        viewEndEditing(true)
     }
 }
 
 extension DetailViewController: UISearchBarDelegate {
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        UIView.animate(withDuration: 0.5) {
-            self.currentState = .full
-            self.collectionView.isHidden = false
-            self.moveView(state: self.currentState)
-        }
+        viewEndEditing(false)
     }
     
     func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-        UIView.animate(withDuration: 0.5) {
-            self.currentState = .partial
-            self.collectionView.isHidden = false
-            self.moveView(state: self.currentState)
-            self.view.endEditing(true)
-        }
+        viewEndEditing(true)
     }
     
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchBarTextDidEndEditing(searchBar)
+    }
+
+    func viewEndEditing(_ endEditing: Bool) {
+        UIView.animate(withDuration: 0.5) {
+            if endEditing {
+                self.currentState = .partial
+                self.view.endEditing(endEditing)
+            } else {
+                self.currentState = .full
+            }
+            self.collectionView.isHidden = false
+            self.moveView(state: self.currentState)
+        }
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -266,6 +266,7 @@ extension DetailViewController: UICollectionViewDelegate {
               let lng = cell.latLng?.lng else {
             return
         }
+        collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
         delegate?.didCellSelected(lat: lat, lng: lng, isClicked: cell.isClicked)
         cell.isClicked = true
         prevClickedCell?.isClicked = false

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/View/DetailCollectionViewCell.swift
@@ -8,10 +8,6 @@
 import UIKit
 
 class DetailCollectionViewCell: UICollectionViewCell {
-    @IBOutlet weak var nameLabel: UILabel!
-    @IBOutlet weak var categoryLabel: UILabel!
-    @IBOutlet weak var storeImageView: UIImageView!
-    @IBOutlet weak var addressLabel: UILabel!
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(frame: storeImageView.frame)
         indicator.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -19,6 +15,15 @@ class DetailCollectionViewCell: UICollectionViewCell {
         contentView.addSubview(indicator)
         return indicator
     }()
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var categoryLabel: UILabel!
+    @IBOutlet weak var storeImageView: UIImageView! {
+        didSet {
+            storeImageView.layer.cornerRadius = 10
+        }
+    }
+    @IBOutlet weak var addressLabel: UILabel!
     
     var latLng: LatLng?
     var isClicked: Bool = false

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
@@ -116,7 +116,7 @@
                                         <autoresizingMask key="autoresizingMask"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLN-DG-maa">
-                                                <rect key="frame" x="8" y="2.5" width="31" height="15"/>
+                                                <rect key="frame" x="20" y="2.5" width="31" height="15"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -126,7 +126,7 @@
                                         <constraints>
                                             <constraint firstItem="gLN-DG-maa" firstAttribute="centerY" secondItem="wCy-ih-fgg" secondAttribute="centerY" id="JjC-mG-GAo"/>
                                             <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gLN-DG-maa" secondAttribute="trailing" constant="375" id="Kev-Gn-qfj"/>
-                                            <constraint firstItem="gLN-DG-maa" firstAttribute="leading" secondItem="wCy-ih-fgg" secondAttribute="leading" constant="8" id="z3P-NN-ozz"/>
+                                            <constraint firstItem="gLN-DG-maa" firstAttribute="leading" secondItem="wCy-ih-fgg" secondAttribute="leading" constant="20" id="z3P-NN-ozz"/>
                                         </constraints>
                                         <connections>
                                             <outlet property="poiNumberLabel" destination="gLN-DG-maa" id="rqy-DB-Q7T"/>

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
@@ -69,7 +69,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Icon" translatesAutoresizingMaskIntoConstraints="NO" id="gLB-Nw-XXB">
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon" translatesAutoresizingMaskIntoConstraints="NO" id="gLB-Nw-XXB">
                                                         <rect key="frame" x="306" y="15" width="98" height="98"/>
                                                         <color key="backgroundColor" red="0.38888341189999998" green="0.84166854619999998" blue="0.50189584490000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                         <constraints>
@@ -164,7 +164,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Icon" width="541" height="540"/>
+        <image name="icon" width="541" height="540"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
@@ -64,19 +64,18 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="category" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g3v-xr-SEP">
-                                                        <rect key="frame" x="20" y="59" width="173" height="19"/>
+                                                        <rect key="frame" x="20" y="59" width="163" height="19"/>
                                                         <fontDescription key="fontDescription" name="NanumSquareRoundOTFR" family="NanumSquareRoundOTF" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon" translatesAutoresizingMaskIntoConstraints="NO" id="gLB-Nw-XXB">
-                                                        <rect key="frame" x="306" y="15" width="98" height="98"/>
-                                                        <color key="backgroundColor" red="0.38888341189999998" green="0.84166854619999998" blue="0.50189584490000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="slash.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="gLB-Nw-XXB">
+                                                        <rect key="frame" x="296" y="12" width="108" height="103.5"/>
+                                                        <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="gLB-Nw-XXB" secondAttribute="height" multiplier="1:1" id="3OU-RA-oQJ"/>
-                                                            <constraint firstAttribute="width" constant="98" id="C00-x9-zYd"/>
-                                                            <constraint firstAttribute="height" constant="98" id="dUR-DH-pVz"/>
                                                         </constraints>
+                                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r8i-iz-hdi">
                                                         <rect key="frame" x="20" y="88" width="48.5" height="25"/>
@@ -91,7 +90,9 @@
                                                     <constraint firstItem="g3v-xr-SEP" firstAttribute="leading" secondItem="WNb-u9-a3J" secondAttribute="leading" constant="20" id="3Sp-JS-Um0"/>
                                                     <constraint firstItem="gLB-Nw-XXB" firstAttribute="leading" secondItem="g3v-xr-SEP" secondAttribute="trailing" constant="113" id="6aa-gG-Vah"/>
                                                     <constraint firstItem="r8i-iz-hdi" firstAttribute="top" secondItem="g3v-xr-SEP" secondAttribute="bottom" constant="10" id="ADz-qs-3h1"/>
+                                                    <constraint firstItem="gLB-Nw-XXB" firstAttribute="top" secondItem="WNb-u9-a3J" secondAttribute="top" constant="10" id="Hvq-bo-FlL"/>
                                                     <constraint firstAttribute="trailing" secondItem="gLB-Nw-XXB" secondAttribute="trailing" constant="10" id="Jtf-70-iD7"/>
+                                                    <constraint firstAttribute="bottom" secondItem="gLB-Nw-XXB" secondAttribute="bottom" constant="10" id="M55-s9-Wu4"/>
                                                     <constraint firstItem="gLB-Nw-XXB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="seo-84-VDA" secondAttribute="trailing" constant="20" id="Mbj-yZ-PV1"/>
                                                     <constraint firstItem="gLB-Nw-XXB" firstAttribute="centerY" secondItem="WNb-u9-a3J" secondAttribute="centerY" id="RM8-Z9-dDT"/>
                                                     <constraint firstItem="seo-84-VDA" firstAttribute="top" secondItem="WNb-u9-a3J" secondAttribute="top" constant="20" id="aQW-Yu-PjB"/>
@@ -164,7 +165,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="icon" width="541" height="540"/>
+        <image name="slash.circle" catalog="system" width="128" height="121"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
## 스크롤 단계 개선
- 좌표 위치로 단계 구분
- 이전 상태와 같을 경우, velocity로 구분
- 스크롤 단계에 따라 hidden 여부 결정
![1](https://user-images.githubusercontent.com/45285737/101337188-b82f9580-38be-11eb-9b6f-015c558f4e98.gif)

## SearchBar
- 서치바 클릭 시, 스크롤 단계 full
- cancel 클릭 시, 스크롤 단계 partial 후 endEditing
![2](https://user-images.githubusercontent.com/45285737/101337260-c978a200-38be-11eb-8dde-da5c4396c575.gif)

## 디자인 변경
### CollectonView
- clipToBounds 적용으로 cornerRadius 적용 안되던 문제 수정
- count label 위치 조정
### Cell
- 디폴트 이미지 변경
- 이미지 뷰 cornerRadius 적용