### PR TITLE
[Feature/address_fetch_each_cell] DetailView의 주소를 각 셀마다 불러오도록 수정

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/BoostClusteringMaB.xcdatamodeld/BoostClusteringMaB.xcdatamodel/contents
+++ b/BoostClusteringMaB/BoostClusteringMaB/BoostClusteringMaB.xcdatamodeld/BoostClusteringMaB.xcdatamodel/contents
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20B29" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ManagedPOI" representedClassName="ManagedPOI" syncable="YES">
-        <attribute name="address" optional="YES" attributeType="String"/>
         <attribute name="category" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="String"/>
@@ -10,6 +9,6 @@
         <attribute name="name" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="ManagedPOI" positionX="-63" positionY="-18" width="128" height="148"/>
+        <element name="ManagedPOI" positionX="-63" positionY="-18" width="128" height="119"/>
     </elements>
 </model>

--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/CoreDataLayer.swift
@@ -69,24 +69,26 @@ final class CoreDataLayer: CoreDataManager {
             return
         }
         
-        addressAPI.address(lat: latitude, lng: longitude) { result in
-            guard let address = try? self.jsonParser.parse(address: result.get()) else { return }
-            self.childContext.perform { [weak self] in
-                guard let self = self else {
+        childContext.perform { [weak self] in
+            guard let self = self else {
+                return
+            }
+            let poi = ManagedPOI(context: self.childContext)
+            poi.id = place.id
+            poi.category = place.category
+            poi.imageURL = place.imageURL
+            poi.latitude = latitude
+            poi.longitude = longitude
+            poi.name = place.name
+            if isSave {
+                do {
+                    try self.save()
+                } catch {
+                    handler?(.failure(.saveError))
                     return
                 }
-                let poi = ManagedPOI(context: self.childContext)
-                poi.fromPOI(place, address)
-                if isSave {
-                    do {
-                        try self.save()
-                    } catch {
-                        handler?(.failure(.saveError))
-                        return
-                    }
-                }
-                handler?(.success(()))
             }
+            handler?(.success(()))
         }
     }
     

--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/ManagedPOI+CoreDataClass.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/ManagedPOI+CoreDataClass.swift
@@ -13,12 +13,11 @@ import CoreData
 public class ManagedPOI: NSManagedObject {
     func toPOI() -> POI {
         let latlng = LatLng(lat: latitude, lng: longitude)
-        let poi = POI(address: address, category: category, id: id, imageURL: imageURL, latLng: latlng, name: name)
+        let poi = POI(category: category, id: id, imageURL: imageURL, latLng: latlng, name: name)
         return poi
     }
     
-    func fromPOI(_ poi: Place, _ addressPlace: String) {
-        address = addressPlace
+    func fromPOI(_ poi: Place) {
         category = poi.category
         id = poi.id
         imageURL = poi.imageURL

--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/ManagedPOI+CoreDataProperties.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/ManagedPOI+CoreDataProperties.swift
@@ -15,7 +15,6 @@ extension ManagedPOI {
         return NSFetchRequest<ManagedPOI>(entityName: "ManagedPOI")
     }
     
-    @NSManaged public var address: String?
     @NSManaged public var category: String?
     @NSManaged public var id: String?
     @NSManaged public var imageURL: String?

--- a/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/POI.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/CoreData/Models/POI.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct POI: Equatable {
-    var address: String?
     var category: String?
     var id: String?
     var imageURL: String?

--- a/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Util/AddressAPI.swift
@@ -8,20 +8,44 @@
 import Foundation
 
 protocol AddressAPIService {
-    func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?)
+    func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) -> URLSessionDataTask?
 }
 
 final class AddressAPI: AddressAPIService {
     enum AddressAPIError: Error {
         case nmfClientError
     }
+    private let addressCache = NSCache<NSURL, NSData>()
     
-    func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) {
-        let baseURL = "https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc"
-        guard let url = URL(string: "\(baseURL)?coords=\(lng),\(lat)&output=json&orders=roadaddr") else { return }
-        guard let id = Bundle.main.infoDictionary?["NMFClientId"] as? String,
-              let secret = Bundle.main.infoDictionary?["NMFClientSecret"] as? String
-        else { completion?(.failure(AddressAPIError.nmfClientError)); return }
+    let NMFClientId = "NMFClientId"
+    let NMFClientSecret = "NMFClientSecret"
+    
+    let apiKeyID = "X-NCP-APIGW-API-KEY-ID"
+    let apiKey = "X-NCP-APIGW-API-KEY"
+
+    private func url(lat: Double, lng: Double) -> URL? {
+        var components = URLComponents(string: "https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc")
+        let coords = URLQueryItem(name: "coords", value: "\(lng),\(lat)")
+        let output = URLQueryItem(name: "output", value: "json")
+        let orders = URLQueryItem(name: "orders", value: "roadaddr")
+        
+        components?.queryItems = [coords, output, orders]
+        return components?.url
+    }
+    
+    func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) -> URLSessionDataTask? {
+        guard let url = url(lat: lat, lng: lng),
+              let id = Bundle.main.infoDictionary?[NMFClientId] as? String,
+              let secret = Bundle.main.infoDictionary?[NMFClientSecret] as? String else {
+            completion?(.failure(AddressAPIError.nmfClientError))
+            return nil
+        }
+        
+        // check cached address
+        if let cached = addressCache.object(forKey: url as NSURL) {
+            completion?(.success(cached as Data))
+            return nil
+        }
         
         var request = URLRequest(url: url)
         
@@ -30,22 +54,28 @@ final class AddressAPI: AddressAPIService {
             "X-NCP-APIGW-API-KEY": secret
         ]
         
-        URLSession.shared.dataTask(with: request) { (data, response, error) in
-            if let error = error {
-                completion?(.failure(error))
-                return
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            DispatchQueue.main.async {
+                if let error = error {
+                    completion?(.failure(error))
+                    return
+                }
+                
+                guard let httpResponse = response as? HTTPURLResponse,
+                      200...299 ~= httpResponse.statusCode else {
+                    completion?(.failure(AddressAPIError.nmfClientError))
+                    debugPrint(response ?? "")
+                    return
+                }
+                
+                guard let data = data else { return }
+                
+                self.addressCache.setObject(data as NSData, forKey: url as NSURL)
+                completion?(.success(data))
             }
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  200...299 ~= httpResponse.statusCode else {
-                completion?(.failure(AddressAPIError.nmfClientError))
-                debugPrint(response ?? "")
-                return
-            }
-            
-            guard let data = data else { return }
-            
-            completion?(.success(data))
-        }.resume()
+        }
+        
+        task.resume()
+        return task
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
+++ b/BoostClusteringMaB/BoostClusteringMaBTests/CoreData/CoreDataTests.swift
@@ -16,28 +16,9 @@ class CoreDataTests: XCTestCase {
                          y: "35.55532",
                          imageURL: nil,
                          category: "부스트캠프")
-
-    class AddressAPIMock: AddressAPIService {
-        func address(lat: Double, lng: Double, completion: ((Result<Data, Error>) -> Void)?) {
-            completion?(.success(.init()))
-        }
-    }
-
-    class JSONParserMock: JsonParserService {
-        func parse(fileName: String, completion handler: @escaping (Result<[Place], Error>) -> Void) {
-            handler(.success([]))
-        }
-
-        func parse(address: Data) -> String? {
-            return ""
-        }
-    }
-
     func testAddPOI() throws {
         // Given
         let layer = CoreDataLayer()
-        layer.addressAPI = AddressAPIMock()
-        layer.jsonParser = JSONParserMock()
 
         timeout(10) { expectation in
             // When
@@ -165,8 +146,6 @@ class CoreDataTests: XCTestCase {
     func testRemove() throws {
         // Given
         let layer = CoreDataLayer()
-        layer.addressAPI = AddressAPIMock()
-        layer.jsonParser = JSONParserMock()
         
         timeout(20) { expectation in
             layer.add(place: newPlace) { _ in


### PR DESCRIPTION
## DetailView의 주소를 각 셀마다 불러오도록 수정

### 구현 내용
- CoreData모델에서 address 항목 제거
- CoreData 테스트 코드에서 addressAPI 의존성 제거
- AddressAPI 에서 받아온 Data를 NSCache를 이용하여 캐싱
- DetailCollectionView에서 AddressAPI의 DataTask를 가지고 있다가 재사용 될 때 마다 cancel하도록 수정