### PR TITLE
[feature/improving marker] 클러스터 마커 이미지(뷰) 변경

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB.xcodeproj/project.pbxproj
+++ b/BoostClusteringMaB/BoostClusteringMaB.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		709707D825760BF900D3FC36 /* ManagedPOI+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709707D625760BF900D3FC36 /* ManagedPOI+CoreDataClass.swift */; };
 		709707D925760BF900D3FC36 /* ManagedPOI+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709707D725760BF900D3FC36 /* ManagedPOI+CoreDataProperties.swift */; };
 		709708052577219700D3FC36 /* ClusteringProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709708042577219700D3FC36 /* ClusteringProtocol.swift */; };
-		7097080A2577228900D3FC36 /* MarkerAnimateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709708092577228900D3FC36 /* MarkerAnimateController.swift */; };
+		7097080A2577228900D3FC36 /* MainAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709708092577228900D3FC36 /* MainAnimationController.swift */; };
 		70BA50F02562B0950076920D /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 70BA50EF2562B0950076920D /* .swiftlint.yml */; };
 		70BFFD5C256CB9360048CEA6 /* CSVParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BFFD5B256CB9360048CEA6 /* CSVParser.swift */; };
 		70BFFD79256CD4BE0048CEA6 /* CSVParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BFFD78256CD4BE0048CEA6 /* CSVParserTests.swift */; };
@@ -114,7 +114,7 @@
 		709707D625760BF900D3FC36 /* ManagedPOI+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ManagedPOI+CoreDataClass.swift"; sourceTree = "<group>"; };
 		709707D725760BF900D3FC36 /* ManagedPOI+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ManagedPOI+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		709708042577219700D3FC36 /* ClusteringProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusteringProtocol.swift; sourceTree = "<group>"; };
-		709708092577228900D3FC36 /* MarkerAnimateController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkerAnimateController.swift; path = BoostClusteringMaB/MarkerAnimateController.swift; sourceTree = SOURCE_ROOT; };
+		709708092577228900D3FC36 /* MainAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MainAnimationController.swift; path = BoostClusteringMaB/MainAnimationController.swift; sourceTree = SOURCE_ROOT; };
 		70BA50EF2562B0950076920D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		70BFFD5B256CB9360048CEA6 /* CSVParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVParser.swift; sourceTree = "<group>"; };
 		70BFFD78256CD4BE0048CEA6 /* CSVParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVParserTests.swift; sourceTree = "<group>"; };
@@ -177,7 +177,7 @@
 		0D0172CD2570C15100A26886 /* Animations */ = {
 			isa = PBXGroup;
 			children = (
-				709708092577228900D3FC36 /* MarkerAnimateController.swift */,
+				709708092577228900D3FC36 /* MainAnimationController.swift */,
 			);
 			path = Animations;
 			sourceTree = "<group>";
@@ -710,7 +710,7 @@
 				0DF97E36256B9F330007BCEE /* MarkerImageView.swift in Sources */,
 				70BFFD5C256CB9360048CEA6 /* CSVParser.swift in Sources */,
 				F4A07BB225711B1900B18415 /* LoadViewController.swift in Sources */,
-				7097080A2577228900D3FC36 /* MarkerAnimateController.swift in Sources */,
+				7097080A2577228900D3FC36 /* MainAnimationController.swift in Sources */,
 				C3A28799256F986D00DF23B1 /* Clustering.swift in Sources */,
 				C3FB086B256B8D8D00B93665 /* POIModel.swift in Sources */,
 				70387DD2256DEB9900F138CB /* CoreDataContainer.swift in Sources */,

--- a/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
@@ -9,7 +9,7 @@ import Foundation
 import NMapsMap
 
 extension NMFMarker {
-    static let maxBaseRadius: CGFloat = 15
+    static let maxBaseRadius: CGFloat = 20
     static let markerImageView = MarkerImageView(radius: maxBaseRadius)
     
     /// 위치와 갯수를 입력하면 NMFMarker배열로 만들어줌

--- a/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
@@ -9,8 +9,8 @@ import Foundation
 import NMapsMap
 
 extension NMFMarker {
-    static let maxBaseRadius: CGFloat = 20
-    static let markerImageView = MarkerImageView(radius: maxBaseRadius)
+    static let maxSize: CGFloat = 80
+    static let markerImageView = MarkerImageView(size: maxSize)
     
     /// 위치와 갯수를 입력하면 NMFMarker배열로 만들어줌
     /// - Parameters:
@@ -43,7 +43,7 @@ extension NMFMarker {
     ///   - size: 클러스터 크기 비율
     func setImageView(_ view: MarkerImageView, count: Int, sizeRatio: CGFloat) {
         view.text = "\(count)"
-        view.radius = NMFMarker.maxBaseRadius * (1 + sizeRatio)
+        view.size = NMFMarker.maxSize * (1 + sizeRatio) / 2
         iconImage = .init(image: view.snapshot())
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Extension/NMFMarker+.swift
@@ -40,7 +40,7 @@ extension NMFMarker {
     /// - Parameters:
     ///   - view: MarkerImageView
     ///   - count: 클러스터 안에 POI 갯수
-    ///   - size: 클러스터 크기 비율
+    ///   - sizeRatio: 클러스터 크기 비율
     func setImageView(_ view: MarkerImageView, count: Int, sizeRatio: CGFloat) {
         view.text = "\(count)"
         view.size = NMFMarker.maxSize * (1 + sizeRatio) / 2

--- a/BoostClusteringMaB/BoostClusteringMaB/MainAnimationController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/MainAnimationController.swift
@@ -145,8 +145,10 @@ final class MainAnimationController {
             dstPointView.transform = .identity
             dstPointView.alpha = 1
         }, completion: {
-            srcPointView?.removeFromSuperview()
-            dstPointView.removeFromSuperview()
+            Timer.scheduledTimer(withTimeInterval: 0.05, repeats: false) { _ in
+                srcPointView?.removeFromSuperview()
+                dstPointView.removeFromSuperview()
+            }
         })
     }
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/MainAnimationController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/MainAnimationController.swift
@@ -1,5 +1,5 @@
 //
-//  MarkerAnimator.swift
+//  MainAnimationController.swift
 //  BoostClusteringMaB
 //
 //  Created by 현기엽 on 2020/11/27.
@@ -7,10 +7,23 @@
 import UIKit
 import NMapsMap
 
-final class MarkerAnimateController {
+final class MainAnimationController {
     typealias AnimationModel = (latLng: NMGLatLng, size: CGFloat)
+    
+    private lazy var dotView: UIView = {
+        let dot = UIView(frame: .init(x: 0, y: 0, width: self.dotSize, height: self.dotSize))
+        dot.layer.cornerRadius = self.dotSize / 2
+        dot.backgroundColor = .red
+        view?.addSubview(dot)
+        return dot
+    }()
+    
+    private let dotSize: CGFloat = 4
     private let mapView: NMFMapViewProtocol
-    private var animator: UIViewPropertyAnimator?
+    
+    private var markerAnimator: UIViewPropertyAnimator?
+    private var dotAnimator: UIViewPropertyAnimator?
+    
     var view: UIView?
     
     init(frame: CGRect, mapView: NMFMapViewProtocol) {
@@ -48,8 +61,30 @@ final class MarkerAnimateController {
         start(animations: animations, completion: completion)
     }
     
+    func pointDotAnimation(point: CGPoint) {
+        dotView.center = .init(x: point.x, y: point.y)
+        self.dotView.isHidden = false
+        self.dotView.alpha = 1
+        dotAnimator = UIViewPropertyAnimator.runningPropertyAnimator(
+            withDuration: 0.3,
+            delay: 0,
+            options: .repeat,
+            animations: {
+                UIView.setAnimationRepeatCount(.infinity)
+                self.dotView.alpha = 0
+            }, completion: { _ in
+                self.dotView.alpha = 1
+            })
+    }
+    
+    func removePointAnimation() {
+        dotAnimator?.stopAnimation(false)
+        dotAnimator?.finishAnimation(at: .current)
+        self.dotView.isHidden = true
+    }
+    
     private func start(animations: [(animation: () -> Void, completion: () -> Void)], completion: (() -> Void)?) {
-        animator = UIViewPropertyAnimator.runningPropertyAnimator(
+        markerAnimator = UIViewPropertyAnimator.runningPropertyAnimator(
             withDuration: 0.5,
             delay: 0,
             options: .curveEaseInOut,
@@ -65,8 +100,8 @@ final class MarkerAnimateController {
     }
     
     private func stop() {
-        animator?.stopAnimation(false)
-        animator?.finishAnimation(at: .current)
+        markerAnimator?.stopAnimation(false)
+        markerAnimator?.finishAnimation(at: .current)
     }
     
     private func moveWithAnimation(from srcModel: AnimationModel,

--- a/BoostClusteringMaB/BoostClusteringMaB/MarkerAnimateController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/MarkerAnimateController.swift
@@ -8,14 +8,12 @@ import UIKit
 import NMapsMap
 
 final class MarkerAnimateController {
-    typealias AnimationModel = (latLng: NMGLatLng, radius: CGFloat)
-    private let markerRadius: CGFloat
+    typealias AnimationModel = (latLng: NMGLatLng, size: CGFloat)
     private let mapView: NMFMapViewProtocol
     private var animator: UIViewPropertyAnimator?
     var view: UIView?
     
-    init(frame: CGRect, markerRadius: CGFloat, mapView: NMFMapViewProtocol) {
-        self.markerRadius = markerRadius
+    init(frame: CGRect, mapView: NMFMapViewProtocol) {
         self.mapView = mapView
         configureAnimationView(frame: frame)
     }
@@ -82,26 +80,26 @@ final class MarkerAnimateController {
         
         let srcPointView = MarkerImageView(
             frame: CGRect(
-                x: srcPoint.x - srcModel.radius,
-                y: srcPoint.y - srcModel.radius * 2,
-                width: srcModel.radius * 2,
-                height: srcModel.radius * 2))
+                x: srcPoint.x - srcModel.size / 2,
+                y: srcPoint.y - srcModel.size,
+                width: srcModel.size,
+                height: srcModel.size))
         srcPointView.transform = .identity
         view?.addSubview(srcPointView)
         
         let dstPointView = MarkerImageView(
             frame: CGRect(
-                x: dstPoint.x - dstModel.radius,
-                y: dstPoint.y - dstModel.radius * 2,
-                width: dstModel.radius * 2,
-                height: dstModel.radius * 2
+                x: dstPoint.x - dstModel.size / 2,
+                y: dstPoint.y - dstModel.size,
+                width: dstModel.size,
+                height: dstModel.size
             )
         )
         dstPointView.alpha = 0
         dstPointView.transform = CGAffineTransform(scaleX: 0, y: 0)
         view?.addSubview(dstPointView)
         
-        let scaleValue = dstModel.radius / srcModel.radius
+        let scaleValue = dstModel.size / srcModel.size
         
         return (animation: {
             srcPointView.center = dstPointView.center

--- a/BoostClusteringMaB/BoostClusteringMaB/MarkerAnimateController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/MarkerAnimateController.swift
@@ -71,22 +71,13 @@ final class MarkerAnimateController {
     
     private func moveWithAnimation(from srcModel: AnimationModel,
                                    to dstModel: AnimationModel) -> (() -> Void, () -> Void)? {
+        let scale = dstModel.size / srcModel.size
         let srcPoint = mapView.projection.point(from: srcModel.latLng)
         let dstPoint = mapView.projection.point(from: dstModel.latLng)
         
-        guard srcPoint.isValid, dstPoint.isValid else { return nil }
+        guard srcPoint != dstPoint, dstPoint.isValid else { return nil }
         
-        guard srcPoint != dstPoint else { return nil }
-        
-        let srcPointView = MarkerImageView(
-            frame: CGRect(
-                x: srcPoint.x - srcModel.size / 2,
-                y: srcPoint.y - srcModel.size,
-                width: srcModel.size,
-                height: srcModel.size))
-        srcPointView.transform = .identity
-        view?.addSubview(srcPointView)
-        
+        var srcPointView: MarkerImageView?
         let dstPointView = MarkerImageView(
             frame: CGRect(
                 x: dstPoint.x - dstModel.size / 2,
@@ -99,17 +90,27 @@ final class MarkerAnimateController {
         dstPointView.transform = CGAffineTransform(scaleX: 0, y: 0)
         view?.addSubview(dstPointView)
         
-        let scaleValue = dstModel.size / srcModel.size
+        if srcPoint.isValid {
+            let pointView = MarkerImageView(
+                frame: CGRect(
+                    x: srcPoint.x - srcModel.size / 2,
+                    y: srcPoint.y - srcModel.size,
+                    width: srcModel.size,
+                    height: srcModel.size))
+            pointView.transform = .identity
+            view?.addSubview(pointView)
+            srcPointView = pointView
+        }
         
         return (animation: {
-            srcPointView.center = dstPointView.center
-            srcPointView.transform = CGAffineTransform(scaleX: scaleValue, y: scaleValue)
-            srcPointView.alpha = 0
+            srcPointView?.center = dstPointView.center
+            srcPointView?.transform = CGAffineTransform(scaleX: scale, y: scale)
+            srcPointView?.alpha = 0
             
             dstPointView.transform = .identity
             dstPointView.alpha = 1
         }, completion: {
-            srcPointView.removeFromSuperview()
+            srcPointView?.removeFromSuperview()
             dstPointView.removeFromSuperview()
         })
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -33,7 +33,15 @@ final class DetailViewController: UIViewController {
         return controller
     }()
 
-    private var currentState: State = .minimum
+    private var currentState: State = .minimum {
+        didSet {
+            if currentState == .minimum {
+                collectionView.isHidden = true
+            } else {
+                collectionView.isHidden = false
+            }
+        }
+    }
     private var prevClickedCell: DetailCollectionViewCell?
 
     override func viewDidLoad() {
@@ -52,7 +60,6 @@ final class DetailViewController: UIViewController {
     
     private func configureView() {
         view.clipsToBounds = true
-        collectionView.isHidden = true
         view.layer.cornerRadius = 10
         dragBar.layer.cornerRadius = 3
     }
@@ -140,7 +147,7 @@ extension DetailViewController: UICollectionViewDelegate {
         cell.isClicked = true
         prevClickedCell?.isClicked = false
         prevClickedCell = cell
-        viewEndEditing(true)
+        searchViewEditing(true)
     }
 }
 
@@ -150,26 +157,25 @@ extension DetailViewController: UISearchBarDelegate {
     }
 
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        viewEndEditing(false)
+        searchViewEditing(true)
     }
     
     func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-        viewEndEditing(true)
+        searchViewEditing(false)
     }
     
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchBarTextDidEndEditing(searchBar)
     }
 
-    func viewEndEditing(_ endEditing: Bool) {
+    func searchViewEditing(_ isEditing: Bool) {
         UIView.animate(withDuration: 0.5) {
-            if endEditing {
-                self.currentState = .partial
-                self.view.endEditing(endEditing)
-            } else {
+            if isEditing {
                 self.currentState = .full
+            } else {
+                self.currentState = .partial
+                self.view.endEditing(isEditing)
             }
-            self.collectionView.isHidden = false
             self.moveView(state: self.currentState)
         }
     }
@@ -242,13 +248,10 @@ extension DetailViewController {
 
         switch endedY {
         case ...fullAndPartialBound:
-            collectionView.isHidden = false
             return .full
         case ...partialAndMinimumBound:
-            collectionView.isHidden = false
             return .partial
         default:
-            collectionView.isHidden = true
             return .minimum
         }
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
@@ -22,8 +22,8 @@ protocol MainDisplayLogic: class {
 
 final class MainViewController: UIViewController {
     private lazy var naverMapView = NMFNaverMapView(frame: view.frame)
-    private lazy var markerAnimationController: MarkerAnimateController = {
-        let controller = MarkerAnimateController(frame: view.frame, mapView: mapView)
+    private lazy var animationController: MainAnimationController = {
+        let controller = MainAnimationController(frame: view.frame, mapView: mapView)
         guard let animationView = controller.view else { return controller }
         naverMapView.addSubview(animationView)
         return controller
@@ -42,9 +42,6 @@ final class MainViewController: UIViewController {
     private var interactor: MainBusinessLogic?
     private var mapView: NMFMapView { naverMapView.mapView }
     private var projection: NMFProjection { naverMapView.mapView.projection }
-
-    private var dotView: UIView?
-    private var prevDotView: UIView?
     
     private var highlightMarker: NMFMarker? {
         didSet {
@@ -235,7 +232,7 @@ private extension MainViewController {
                                completion: (() -> Void)?) {
         self.setOverlaysMapView(overlays: oldMarkers, mapView: nil)
 
-        self.markerAnimationController.clusteringAnimation(
+        self.animationController.clusteringAnimation(
             old: oldMarkers.map {
                 (latLng: $0.position, size: $0.iconImage.imageWidth)
             },
@@ -253,7 +250,7 @@ private extension MainViewController {
 
 extension MainViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
-        prevDotView?.layer.removeAllAnimations()
+        animationController.removePointAnimation()
     }
     
     func mapViewCameraIdle(_ mapView: NMFMapView) {
@@ -273,27 +270,16 @@ extension MainViewController: ClusteringTool {
 
 extension MainViewController: DetailViewControllerDelegate {
     func didCellSelected(lat: Double, lng: Double, isClicked: Bool) {
-        prevDotView?.layer.removeAllAnimations()
         if isClicked {
             let cameraUpdate = NMFCameraUpdate(scrollTo: .init(lat: lat, lng: lng), zoomTo: 20)
             cameraUpdate.animation = .easeIn
             cameraUpdate.animationDuration = 0.8
             mapView.moveCamera(cameraUpdate)
         } else {
+            animationController.removePointAnimation()
             let point = convertLatLngToPoint(latLng: LatLng(lat: lat, lng: lng))
-            dotAnimation(point: point)
+            animationController.pointDotAnimation(point: point)
         }
-    }
-
-    func dotAnimation(point: CGPoint) {
-        dotView = UIView(frame: .init(x: point.x, y: point.y, width: 4, height: 4))
-        dotView?.layer.cornerRadius = 2
-        dotView?.backgroundColor = .red
-        self.naverMapView.addSubview(dotView ?? UIView())
-        UIView.animate(withDuration: 0.3, delay: 0, options: .repeat) {
-            self.dotView?.alpha = 0
-        }
-        prevDotView = dotView
     }
 }
 

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
@@ -23,7 +23,7 @@ protocol MainDisplayLogic: class {
 final class MainViewController: UIViewController {
     private lazy var naverMapView = NMFNaverMapView(frame: view.frame)
     private lazy var markerAnimationController: MarkerAnimateController = {
-        let controller = MarkerAnimateController(frame: view.frame, markerRadius: 30, mapView: mapView)
+        let controller = MarkerAnimateController(frame: view.frame, mapView: mapView)
         guard let animationView = controller.view else { return controller }
         naverMapView.addSubview(animationView)
         return controller
@@ -237,10 +237,10 @@ private extension MainViewController {
 
         self.markerAnimationController.clusteringAnimation(
             old: oldMarkers.map {
-                (latLng: $0.position, radius: $0.iconImage.imageWidth / 2)
+                (latLng: $0.position, size: $0.iconImage.imageWidth)
             },
             new: newMarkers.map {
-                (latLng: $0.position, radius: $0.iconImage.imageWidth / 2)
+                (latLng: $0.position, size: $0.iconImage.imageWidth)
             },
             isMerge: oldMarkers.count > newMarkers.count,
             completion: {

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
@@ -8,19 +8,18 @@
 import UIKit
 
 class MarkerImageView: UILabel {
-    var radius: CGFloat {
+    var size: CGFloat {
         get {
-            return frame.width / 2
+            return frame.width
         }
         
         set {
-            frame = .init(x: 0, y: 0, width: newValue * 2, height: newValue * 2)
-            layer.cornerRadius = newValue
+            frame = .init(x: 0, y: 0, width: newValue, height: newValue)
         }
     }
     
-    init(radius: CGFloat) {
-        super.init(frame: .init(x: 0, y: 0, width: radius * 2, height: radius * 2))
+    init(size: CGFloat) {
+        super.init(frame: .init(x: 0, y: 0, width: size * 2, height: size * 2))
         configureView()
     }
     

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
@@ -19,7 +19,7 @@ class MarkerImageView: UILabel {
     }
     
     init(size: CGFloat) {
-        super.init(frame: .init(x: 0, y: 0, width: size * 2, height: size * 2))
+        super.init(frame: .init(x: 0, y: 0, width: size, height: size))
         configureView()
     }
     

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
@@ -35,9 +35,7 @@ class MarkerImageView: UILabel {
     }
     
     private func configureView() {
-        layer.cornerRadius = frame.width / 2
         backgroundColor = UIColor.clear
-        clipsToBounds = true
         textAlignment = .center
         textColor = .naverGreen
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/MarkerImageView.swift
@@ -36,9 +36,47 @@ class MarkerImageView: UILabel {
     
     private func configureView() {
         layer.cornerRadius = frame.width / 2
-        backgroundColor = UIColor.naverGreen
+        backgroundColor = UIColor.clear
         clipsToBounds = true
         textAlignment = .center
+        textColor = .naverGreen
+    }
+    
+    override func draw(_ rect: CGRect) {
+        let center = CGPoint(x: rect.midX, y: rect.minY + rect.height / 3)
+        
+        let path = UIBezierPath()
+        path.move(to: .init(x: rect.midX, y: rect.maxY))
+        path.addLine(to: .init(x: rect.midX + rect.width / 4, y: rect.minY + rect.height / 3))
+        path.addLine(to: .init(x: rect.midX - rect.width / 4, y: rect.minY + rect.height / 3))
+        UIColor.naverGreen.set()
+        path.fill()
+        path.close()
+        
+        let mainCircle = UIBezierPath(arcCenter: center,
+                                      radius: rect.width / 3,
+                                      startAngle: 0,
+                                      endAngle: .pi * 2,
+                                      clockwise: true)
+        UIColor.naverGreen.set()
+        mainCircle.fill()
+        mainCircle.close()
+        
+        let semiCircle = UIBezierPath(arcCenter: center,
+                                      radius: rect.width / 4,
+                                      startAngle: 0,
+                                      endAngle: .pi * 2,
+                                      clockwise: true)
+        UIColor.white.set()
+        semiCircle.fill()
+        semiCircle.close()
+        
+        drawText(in: .init(
+            x: rect.minX,
+            y: rect.minY - rect.height / 6,
+            width: rect.width,
+            height: rect.height
+        ))
     }
 }
 


### PR DESCRIPTION
## 클러스터 마커 이미지(뷰) 변경
- 마커 이미지 뷰의 draw(_ rect:) 를 override
   - UIBezierPath를 이용해 뷰 draw
   - 텍스트는 UILable의 기본 drawText(in:)을 통해 draw
![cluster_marker](https://user-images.githubusercontent.com/45285737/101451462-875b6900-396f-11eb-8844-8c31443a92d6.gif)

## 애니메이션
- 범위 밖 출발 마커를 가진 도착 마커도 애니메이션 가능하게 변경 
- 생성/소멸 시 깜빡임 최소화하기 위해, 애니메이션 뷰를 조금 늦게 제거

## dot animation
- 애니메이션 컨트롤러에 병합
- UIViewPropertyAnimator의 .repeat 옵션이 동작하지 않아 임시로 setAnimationRepeatCount을 사용, 추후 변경해야 함