### PR TITLE
[Feature/detail view size] 디테일뷰가 정상적으로 움직이지 않던 문제 수정

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -275,7 +275,7 @@ extension DetailViewController {
             var duration = abs(distance / recognizer.velocity(in: view).y)
             
             // 애니메이션이 너무 길어서 지루하게 느끼지 않도록 최대 값 설정
-            duration = duration > 1 ? 1 : duration
+            duration = (duration > 1) ? 1 : duration
             
             UIView.animate(withDuration: TimeInterval(duration), delay: 0, options: [.allowUserInteraction]) {
                 self.moveView(state: self.nextState(recognizer))

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -251,10 +251,33 @@ extension DetailViewController {
         }
     }
     
+    private func distance(y: CGFloat, to state: State) -> CGFloat {
+        var destination: CGFloat!
+        
+        switch state {
+        case .minimum:
+            destination = minimumViewYPosition
+        case .partial:
+            destination = partialViewYPosition
+        case .full:
+            destination = fullViewYPosition
+        }
+        
+        return destination - y
+    }
+    
     @objc private func panGesture(_ recognizer: UIPanGestureRecognizer) {
         moveView(panGestureRecognizer: recognizer)
         if recognizer.state == .ended {
-            UIView.animate(withDuration: 0.5, delay: 0, options: [.allowUserInteraction]) {
+            let nextState = self.nextState(recognizer)
+            let endedY = view.frame.minY + recognizer.translation(in: view).y
+            let distance = self.distance(y: endedY, to: nextState)
+            var duration = abs(distance / recognizer.velocity(in: view).y)
+            
+            // 애니메이션이 너무 길어서 지루하게 느끼지 않도록 최대 값 설정
+            duration = duration > 1 ? 1 : duration
+            
+            UIView.animate(withDuration: TimeInterval(duration), delay: 0, options: [.allowUserInteraction]) {
                 self.moveView(state: self.nextState(recognizer))
             }
             


### PR DESCRIPTION
## partial 상태의 디테일뷰를 위로 올렸다가 아래쪽 방향으로 움직인다음 손을 떼면 minimum 상태로 설정되는 문제 수정

### 구현 내용
- next와 prev를 미리 설정하는 방식이 아닌 현재 위치를 이용하여 다음 위치를 결정하도록 변경
- 사용자가 이동한 속도를 바탕으로 애니메이션 길이가 변경되도록 수정
  - 애니메이션이 너무 길어서 지루하게 느끼지 않도록 최대 값을 1초로 설정