### PR TITLE
[Feature/detail view size] cancel 버튼이 비활성화(회색) 되어 있을 때도 눌리는 문제

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -18,7 +18,8 @@ final class DetailViewController: UIViewController {
         didSet { searchBar.delegate = self }
     }
     @IBOutlet weak var dragBar: UIView!
-
+    @IBOutlet var cancelButton: UIButton!
+    
     enum Section {
         case main
     }
@@ -127,6 +128,12 @@ final class DetailViewController: UIViewController {
         snapshot.appendItems(fetchedResultsController?.fetchedObjects ?? [], toSection: .main)
         diffableDataSource?.apply(snapshot)
     }
+    
+    @IBAction func cancelButtonTouched(_ sender: Any) {
+        searchBar.text = ""
+        searchViewEditing(false)
+    }
+    
 }
 
 extension DetailViewController: UICollectionViewDelegateFlowLayout {
@@ -174,6 +181,7 @@ extension DetailViewController: UISearchBarDelegate {
     
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchBarTextDidEndEditing(searchBar)
+        searchBar.text = ""
         reloadPOI()
     }
 
@@ -223,7 +231,7 @@ extension DetailViewController {
             }
         }
     }
-
+    
     private func configureGesture() {
         let gesture = UIPanGestureRecognizer(target: self, action: #selector(panGesture))
         view.addGestureRecognizer(gesture)
@@ -234,15 +242,23 @@ extension DetailViewController {
         switch state {
         case .minimum:
             yPosition = minimumViewYPosition
+            setCancelButtonEnable(false)
         case .partial:
             yPosition = partialViewYPosition
+            setCancelButtonEnable(false)
         case .full:
             yPosition = fullViewYPosition
+            setCancelButtonEnable(true)
         }
         view.frame = CGRect(x: 0, y: yPosition, width: view.frame.width, height: view.frame.height)
         currentState = state
     }
 
+    private func setCancelButtonEnable(_ isEnable: Bool) {
+        cancelButton.isUserInteractionEnabled = isEnable
+        cancelButton.setTitleColor(isEnable ? .black : .gray, for: .normal)
+    }
+    
     private func moveView(panGestureRecognizer recognizer: UIPanGestureRecognizer) -> State {
         let translation = recognizer.translation(in: view)
         let minY = view.frame.minY
@@ -278,4 +294,5 @@ extension DetailViewController {
             }
         }
     }
+    
 }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -162,7 +162,6 @@ extension DetailViewController: UICollectionViewDelegate {
         cell.isClicked = true
         prevClickedCell?.isClicked = false
         prevClickedCell = cell
-        searchViewEditing(true)
     }
 }
 

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Views/Detail.storyboard
@@ -33,8 +33,8 @@
                                         <constraint firstAttribute="width" constant="40" id="uYB-88-XdR"/>
                                     </constraints>
                                 </view>
-                                <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="가게명 검색" showsCancelButton="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ipo-Rl-NBk">
-                                    <rect key="frame" x="0.0" y="14" width="414" height="56"/>
+                                <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="가게명 검색" translatesAutoresizingMaskIntoConstraints="NO" id="Ipo-Rl-NBk">
+                                    <rect key="frame" x="0.0" y="14" width="364" height="56"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="tintColor" systemColor="labelColor"/>
                                     <color key="barTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -116,14 +116,27 @@
                                         <outlet property="delegate" destination="eWu-xG-s1L" id="opm-V9-hvV"/>
                                     </connections>
                                 </collectionView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S2e-GU-5uK">
+                                    <rect key="frame" x="364" y="14" width="50" height="56"/>
+                                    <state key="normal" title="Cancel">
+                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="cancelButtonTouched:" destination="eWu-xG-s1L" eventType="touchUpInside" id="JNq-Kx-hsD"/>
+                                    </connections>
+                                </button>
                             </subviews>
                             <constraints>
+                                <constraint firstAttribute="trailing" secondItem="S2e-GU-5uK" secondAttribute="trailing" id="2W5-Dd-jo9"/>
                                 <constraint firstItem="UYY-E1-BjH" firstAttribute="top" secondItem="4rf-8i-P0F" secondAttribute="top" constant="8" id="6NC-hZ-ad5"/>
-                                <constraint firstAttribute="trailing" secondItem="Ipo-Rl-NBk" secondAttribute="trailing" id="LbK-F9-meN"/>
+                                <constraint firstItem="S2e-GU-5uK" firstAttribute="top" secondItem="Ipo-Rl-NBk" secondAttribute="top" id="JK7-k7-RtY"/>
+                                <constraint firstAttribute="trailing" secondItem="Ipo-Rl-NBk" secondAttribute="trailing" constant="50" id="LbK-F9-meN"/>
                                 <constraint firstAttribute="bottom" secondItem="Uhn-bq-GyL" secondAttribute="bottom" id="P9Q-bV-PL2"/>
+                                <constraint firstItem="S2e-GU-5uK" firstAttribute="leading" secondItem="Ipo-Rl-NBk" secondAttribute="trailing" id="XMa-I0-cN1"/>
                                 <constraint firstItem="UYY-E1-BjH" firstAttribute="centerX" secondItem="4rf-8i-P0F" secondAttribute="centerX" id="ZkW-ju-mHu"/>
                                 <constraint firstAttribute="trailing" secondItem="Uhn-bq-GyL" secondAttribute="trailing" id="g0f-Yq-jkQ"/>
                                 <constraint firstItem="Ipo-Rl-NBk" firstAttribute="leading" secondItem="4rf-8i-P0F" secondAttribute="leading" id="lLh-AW-JOF"/>
+                                <constraint firstItem="Uhn-bq-GyL" firstAttribute="top" secondItem="S2e-GU-5uK" secondAttribute="bottom" id="mLq-7M-e1U"/>
                                 <constraint firstItem="Ipo-Rl-NBk" firstAttribute="top" secondItem="UYY-E1-BjH" secondAttribute="bottom" id="q3j-RH-QLS"/>
                                 <constraint firstItem="Uhn-bq-GyL" firstAttribute="leading" secondItem="4rf-8i-P0F" secondAttribute="leading" id="tTw-No-t97"/>
                                 <constraint firstItem="Uhn-bq-GyL" firstAttribute="top" secondItem="Ipo-Rl-NBk" secondAttribute="bottom" id="zv1-j2-MLa"/>
@@ -133,6 +146,7 @@
                     </visualEffectView>
                     <size key="freeformSize" width="414" height="896"/>
                     <connections>
+                        <outlet property="cancelButton" destination="S2e-GU-5uK" id="2kx-Fp-Fc7"/>
                         <outlet property="collectionView" destination="Uhn-bq-GyL" id="ZkL-iY-TlX"/>
                         <outlet property="dragBar" destination="UYY-E1-BjH" id="ZuV-mW-y29"/>
                         <outlet property="searchBar" destination="Ipo-Rl-NBk" id="JHc-TV-s3Z"/>


### PR DESCRIPTION
## cancel 버튼이 비활성화(회색) 되어 있을 때도 눌리는 문제

### 요약 
- cancel 누를 시 searchBar의 text를 비워주도록 변경
- fullscreen 아닐때 비활성화

### 구현내용
Cancel 버튼의 경우 기본으로 제공하는 버튼 사용 시 focus가 들어가버려, searchBarTextDidBeginEditing 이 호출 됨.
이를 방지하고자 Custom Cancel Button 을 따로 생성
