### PR TITLE
[Fix/detailview cell double tap] 특정 상황에서 셀을 두번 눌렀을 때 확대되지 않던 문제 수정

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/Detail/DetailViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 import CoreData
 
 protocol DetailViewControllerDelegate: class {
-    func didCellSelected(lat: Double, lng: Double, isClicked: Bool)
+    func moveCamera(to position: LatLng)
+    func dotAnimation(at position: LatLng)
 }
 
 final class DetailViewController: UIViewController {
@@ -49,8 +50,9 @@ final class DetailViewController: UIViewController {
         }
     }
 
-    var prevClickedCell: DetailCollectionViewCell?
-
+    // 이전에 선택된 셀의 indexPath (두번 터치시 확대를 위해 사용)
+    var checkedIndexPath: IndexPath?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
@@ -206,17 +208,25 @@ extension DetailViewController: UICollectionViewDelegateFlowLayout {
 
 extension DetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? DetailCollectionViewCell else { return }
-        guard let lat = cell.latLng?.lat,
-              let lng = cell.latLng?.lng else {
+        guard let cell = collectionView.cellForItem(at: indexPath)
+                as? DetailCollectionViewCell,
+              let latLng = cell.latLng else {
             return
         }
+        
         collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
-        delegate?.didCellSelected(lat: lat, lng: lng, isClicked: cell.isClicked)
-        cell.isClicked = true
-        prevClickedCell?.isClicked = false
-        prevClickedCell = cell
         searchViewEditing(false)
+        
+        if let checkedIndexPath = checkedIndexPath,
+           checkedIndexPath == indexPath {
+            // 두번 누른 경우 -> 확대
+            delegate?.moveCamera(to: latLng)
+            self.checkedIndexPath = nil
+        } else {
+            // 셀 애니메이션 이동 후 indexPath 교체
+            delegate?.dotAnimation(at: latLng)
+            self.checkedIndexPath = indexPath
+        }
     }
 }
 

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
@@ -298,7 +298,7 @@ private extension MainViewController {
 extension MainViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
         animationController.removePointAnimation()
-        bottomSheetViewController.prevClickedCell?.isClicked = false
+        bottomSheetViewController.checkedIndexPath = nil
     }
     
     func mapViewCameraIdle(_ mapView: NMFMapView) {
@@ -317,18 +317,18 @@ extension MainViewController: ClusteringTool {
 }
 
 extension MainViewController: DetailViewControllerDelegate {
-    func didCellSelected(lat: Double, lng: Double, isClicked: Bool) {
-        if isClicked {
-            let cameraUpdate = NMFCameraUpdate(scrollTo: .init(lat: lat, lng: lng),
-                                               zoomTo: 20,
-                                               cameraAnimation: .easeIn,
-                                               duration: 0.8)
-            mapView.moveCamera(cameraUpdate)
-        } else {
-            animationController.removePointAnimation()
-            let point = convertLatLngToPoint(latLng: LatLng(lat: lat, lng: lng))
-            animationController.pointDotAnimation(point: point)
-        }
+    func moveCamera(to position: LatLng) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: position.lat, lng: position.lng),
+                                           zoomTo: 20,
+                                           cameraAnimation: .easeIn,
+                                           duration: 0.8)
+        mapView.moveCamera(cameraUpdate)
+    }
+    
+    func dotAnimation(at position: LatLng) {
+        animationController.removePointAnimation()
+        let point = convertLatLngToPoint(latLng: position)
+        animationController.pointDotAnimation(point: point)
     }
 }
 


### PR DESCRIPTION
## 특정 상황에서 셀을 두번 눌렀을 때 확대되지 않던 문제 수정

### 구현 내용
- 화면을 움직일 때 마다 fetch가 새로 되면서 같은 내용을 가진 셀이라도 비교가 되지 않아 생겼던 문제 수정
- cell을 가지고 있는 대신 indexPath를 이용하여 같은 셀을 눌렀는지 여부 확인