### PR TITLE
[hotfix/marker afterimage] 마커 잔상 문제

### DIFF
--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/Animations/MainAnimationController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/Animations/MainAnimationController.swift
@@ -82,7 +82,7 @@ extension MainAnimationController {
             })
     }
     
-    private func makerAnimationStop() {
+    func makerAnimationStop() {
         markerAnimator?.stopAnimation(false)
         markerAnimator?.finishAnimation(at: .current)
     }

--- a/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
+++ b/BoostClusteringMaB/BoostClusteringMaB/Scenes/MainView/MainViewController.swift
@@ -298,7 +298,11 @@ private extension MainViewController {
 
 extension MainViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
+        animationController.makerAnimationStop()
         animationController.removePointAnimation()
+        displayedData.markers.forEach {
+            $0.mapView = mapView
+        }
         bottomSheetViewController.checkedIndexPath = nil
     }
     


### PR DESCRIPTION
- 애니메이션 중 화면 이동이 있을 경우, 애니메이션 중지 후 현재 마커 즉시 표시